### PR TITLE
added FAQ from translations and updated nl translation

### DIFF
--- a/src/Form/Type/FrequentlyAskedQuestionType.php
+++ b/src/Form/Type/FrequentlyAskedQuestionType.php
@@ -29,10 +29,15 @@ final class FrequentlyAskedQuestionType extends AbstractResourceType
     {
         $builder
             ->add('code', TextType::class, [
+                'label' => 'bitbag_sylius_cms_plugin.ui.code',
                 'disabled' => null !== $builder->getData()->getCode(),
             ])
-            ->add('position', IntegerType::class)
-            ->add('enabled', CheckboxType::class)
+            ->add('position', IntegerType::class, [
+                'label' => 'bitbag_sylius_cms_plugin.ui.position',
+            ])
+            ->add('enabled', CheckboxType::class, [
+                'label' => 'bitbag_sylius_cms_plugin.ui.enabled',
+            ])
             ->add('translations', ResourceTranslationsType::class, [
                 'label' => false,
                 'entry_type' => FrequentlyAskedQuestionTranslationType::class,

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -32,3 +32,4 @@ bitbag_sylius_cms_plugin:
         sections: Sections
         sections_header: Sections
         sections_subheader: Manage your sections
+        position: Position

--- a/src/Resources/translations/messages.nl.yml
+++ b/src/Resources/translations/messages.nl.yml
@@ -2,30 +2,34 @@ bitbag_sylius_cms_plugin:
     ui:
         blocks: Blokken
         pages: Pagina's
-    cms:
-        content_management: Beheer content
-        cms: Beheer content
+        content_management: Beheer inhoud
+        cms: Beheer inhoud
         enabled: Ingeschakeld
-        blocks: Blokken
-        pages: Pagina's
         blocks_header: Blokken
         blocks_subheader: Blokken beheren
-        text_block: Text blok
+        text_block: Tekst blok
         html_block: HTML blok
         image_block: Afbeelding blok
-        pages_header: Pagina
+        pages_header: Pagina's
         pages_subheader: Pagina's beheren
         products: Producten
+        page_related_products: Pagina gerelateerde producten
         name: Naam
         slug: Slug
-        meta_keywords: Meta keywords
-        meta_description: Meta description
+        meta_keywords: Meta sleutelwoorden
+        meta_description: Meta omschrijving
         content: Inhoud
-        form:
-            code: Code
-            enabled: Ingeschakeld
-            name: Naam
-            contents: Inhoud
-            content: Inhoud
-            images: Afbeeldingen
-            link: Link
+        faq: Veelgestelde vragen
+        code: Code
+        contents: Inhoud
+        images: Afbeeldingen
+        link: Link
+        faq_header: Veelgestelde vragen
+        faq_subheader: Beheer veelgestelde vragen
+        frequently_asked_questions: Veelgestelde vragen
+        question: Vraag
+        answer: Antwoord
+        sections: Secties
+        sections_header: Secties
+        sections_subheader: Beheer secties
+        position: Positie

--- a/src/Resources/translations/validators.nl.yml
+++ b/src/Resources/translations/validators.nl.yml
@@ -5,34 +5,60 @@ bitbag_sylius_cms_plugin:
             not_blank: Afbeelding kan niet leeg zijn.
         code:
             unique: Code moet uniek zijn.
-            not_blank: Gelieve een code in te vullen.
+            not_blank: Code is verplicht en mag niet leeg zijn.
             min_length: Code moet minstens {{ limit }} tekens lang zijn.
-            max_length: Code mag niet langer zijn dan {{ limit }} characters.
+            max_length: Code mag niet langer zijn dan {{ limit }} tekens.
         name:
-            min_length: Name moet minstens {{ limit }} tekens lang zijn.
-            max_length: Name mag niet langer zijn dan {{ limit }} characters.
+            min_length: Naam moet minstens {{ limit }} tekens lang zijn.
+            max_length: Naam mag niet langer zijn dan {{ limit }} tekens.
         content:
-            min_length: Content moet minstens {{ limit }} tekens lang zijn.
+            not_blank: Inhoud is verplicht en mag niet leeg zijn.
+            min_length: Inhoud moet minstens {{ limit }} tekens lang zijn.
     page:
         code:
             unique: Code moet uniek zijn.
-            not_blank: Gelieve een code in te vullen.
+            not_blank: Code is verplicht en mag niet leeg zijn.
             min_length: Code moet minstens {{ limit }} tekens lang zijn.
-            max_length: Code mag niet langer zijn dan {{ limit }} characters.
+            max_length: Code mag niet langer zijn dan {{ limit }} tekens.
         name:
-            not_blank: Voer een paginanaam in.
-            min_length: Name moet minstens {{ limit }} tekens lang zijn.
-            max_length: Name mag niet langer zijn dan {{ limit }} characters.
+            not_blank: Naam is verplicht en mag niet leeg zijn.
+            min_length: Naam moet minstens {{ limit }} tekens lang zijn.
+            max_length: Naam mag niet langer zijn dan {{ limit }} tekens.
         slug:
-            not_blank: Voer een slug in.
+            not_blank: Slug is verplicht en mag niet leeg zijn.
             min_length: Slug moet minstens {{ limit }} tekens lang zijn.
-            max_length: Slug mag niet langer zijn dan {{ limit }} characters.
+            max_length: Slug mag niet langer zijn dan {{ limit }} tekens.
         meta_keywords:
-            min_length: Meta keywords moet minstens {{ limit }} tekens lang zijn.
-            max_length: Meta keywords mag niet langer zijn dan {{ limit }} characters.
+            min_length: Meta sleutelwoorden moeten minstens {{ limit }} tekens lang zijn.
+            max_length: Meta sleutelwoorden mogen niet langer zijn dan {{ limit }} tekens.
         meta_description:
-            min_length: Meta description moet minstens {{ limit }} tekens lang zijn.
-            max_length: Meta description mag niet langer zijn dan {{ limit }} characters.
+            min_length: Meta omschrijving moet minstens {{ limit }} tekens lang zijn.
+            max_length: Meta omschrijving mag niet langer zijn dan {{ limit }} tekens.
         content:
-            not_blank: Voer inhoud in.
+            not_blank: Inhoud is verplicht en mag niet leeg zijn.
             min_length: Inhoud moet minstens {{ limit }} tekens lang zijn.
+    frequently_asked_question:
+        code:
+            unique: Er bestaat al een veelgestelde vraag met deze code.
+            not_blank: Code is verplicht en mag niet leeg zijn.
+            min_length: Code moet minstens {{ limit }} tekens lang zijn.
+            max_length: Code mag niet langer zijn dan {{ limit }} tekens.
+        position:
+            unique: Er bestaat al een veelgestelde vraag met deze positie.
+            not_blank: Positie is verplicht en mag niet leeg zijn.
+        question:
+            not_blank: Vraag is verplicht en mag niet leeg zijn.
+            min_length: Vraag oet minstens {{ limit }} tekens lang zijn.
+        answer:
+            not_blank: Antwoord is verplicht en mag niet leeg zijn.
+            min_length: Antwoord moet minstens {{ limit }} tekens lang zijn.
+    section:
+        code:
+            unique: Er bestaat al een sectie met deze code.
+            not_blank: Code is verplicht en mag niet leeg zijn.
+            min_length: Code moet minstens {{ limit }} tekens lang zijn.
+            max_length: Code mag niet langer zijn dan {{ limit }} tekens.
+        name:
+            not_blank: Naam is verplicht en mag niet leeg zijn.
+            min_length: Naam moet minstens {{ limit }} tekens lang zijn.
+            max_length: Naam mag niet langer zijn dan {{ limit }} tekens.


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

Due to issue #97 using a English cms user wasn't an option for the time being so i decided to update the Dutch translations and found the FAQ form type hadn't been translated. I based the 'messages' translation on the English translation file and tossed out all the stuff that wasn't in there to prevent unused translations being present.