### PR TITLE
Fix route typo in fixtures

### DIFF
--- a/tests/Application/app/config/fixtures.yml
+++ b/tests/Application/app/config/fixtures.yml
@@ -90,7 +90,7 @@ sylius_fixtures:
                                             <div class="ignored info ui message">On the other hand, the block on the right is a block associated with specific products.</div>
                                             <p>This approach can be helpful with displaying some content dedicated to specific products, like size table or product story</p>
                                             <p>The way you render it is similar to the one from above example:</p>
-                                            <pre>{{ render(path('bitbag_syius_cms_plugin_shop_block_index_by_product_code', {'productCode' : product.code, 'template' : '@BitBagSyliusCmsPlugin/Shop/Block/index.html.twig'})) }}</pre>
+                                            <pre>{{ render(path('bitbag_sylius_cms_plugin_shop_block_index_by_product_code', {'productCode' : product.code, 'template' : '@BitBagSyliusCmsPlugin/Shop/Block/index.html.twig'})) }}</pre>
                             size_table:
                                 type: image
                                 products: 5


### PR DESCRIPTION
Fixed url route typo in fixtures, used for https://demo.bitbag.shop/

| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT
