### PR TITLE
Fix a wrong configuration in the Page resource

### DIFF
--- a/src/Resources/config/grids/admin/page.yml
+++ b/src/Resources/config/grids/admin/page.yml
@@ -41,7 +41,7 @@ sylius_grid:
                     type: string
                     label: sylius.ui.search
                     options:
-                        fields: [code, type]
+                        fields: [code]
             actions:
                 main:
                     create:


### PR DESCRIPTION
Fix a wrong configuration in the declaration of the Page resource, causing an 500 error when searching a page in admin. The `type` field does not exists in the entity, it should be removed.

| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #140 
| License         | MIT
