### PR TITLE
Improve the parser method to allow multiple function calls

### DIFF
--- a/src/Twig/Parser/ContentParser.php
+++ b/src/Twig/Parser/ContentParser.php
@@ -32,17 +32,22 @@ final class ContentParser implements ContentParserInterface
     {
         $functions = $this->twigEnvironment->getFunctions();
 
-        foreach ($this->enabledFunctions as $function) {
-            if (null !== $arguments = $this->getFunctionArguments($function, $input)) {
-                $functionCall = '{{ ' . $function . '(\'' . rtrim(implode($arguments, '\' ,'), '\' ,') . '\') }}';
+        preg_match_all('`{{\s*(?P<method>.+)\s*\((?P<arguments>.*)\)\s*}}`', $input, $callMatches);
 
+        foreach ($callMatches[0] as $index => $call) {
+            $function = $callMatches['method'][$index];
+            if (!in_array($function, $this->enabledFunctions)) {
+                continue;
+            }
+
+            if (null !== $arguments = $this->getFunctionArguments($function, $call)) {
                 try {
                     $functionResult = $this->callFunction($functions, $function, $arguments);
                 } catch (\Exception $exception) {
                     $functionResult = '';
                 }
 
-                $input = str_replace($functionCall, $functionResult, $input);
+                $input = str_replace($call, $functionResult, $input);
             }
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #192
| License         | MIT

Hi,
According to #192, I updated the parser to allow more than one function call in content of CMS pages.

I didn't write the tests because:
- Change of the fixtures is required I think.
- Should be tested in `\spec\BitBag\SyliusCmsPlugin\Twig\Parser\ContentParserSpec::it_parses_string_functions`.
- No time? 😄 

So, of course allow you to update the PR to make this fix a reality. I did that in my fork to go forward and avoid being blocked. Feel free! I can help in any way, I'm on Slack also.