### PR TITLE
Fix template path in controllers config

### DIFF
--- a/src/Resources/config/routing/admin/block.yml
+++ b/src/Resources/config/routing/admin/block.yml
@@ -12,7 +12,7 @@ bitbag_sylius_cms_plugin_admin_block:
                 header: bitbag_sylius_cms_plugin.ui.blocks_header
                 subheader: bitbag_sylius_cms_plugin.ui.blocks_subheader
                 templates:
-                    form: BitBagSyliusCmsPlugin:Block:Crud/_form.html.twig
+                    form: "@BitBagSyliusCmsPlugin/Block/Crud/_form.html.twig"
             index:
                 icon: block layout
             route:

--- a/src/Resources/config/routing/admin/frequently_asked_question.yml
+++ b/src/Resources/config/routing/admin/frequently_asked_question.yml
@@ -12,7 +12,7 @@ bitbag_sylius_cms_plugin_admin_frequently_asked_question:
                 header: bitbag_sylius_cms_plugin.ui.faq_header
                 subheader: bitbag_sylius_cms_plugin.ui.faq_subheader
                 templates:
-                    form: BitBagSyliusCmsPlugin:FrequentlyAskedQuestion:Crud/_form.html.twig
+                    form: "@BitBagSyliusCmsPlugin/FrequentlyAskedQuestion/Crud/_form.html.twig"
             index:
                 icon: help
     type: sylius.resource

--- a/src/Resources/config/routing/admin/media.yml
+++ b/src/Resources/config/routing/admin/media.yml
@@ -12,7 +12,7 @@ bitbag_sylius_cms_plugin_admin_media:
                 header: bitbag_sylius_cms_plugin.ui.media_header
                 subheader: bitbag_sylius_cms_plugin.ui.media_subheader
                 templates:
-                    form: BitBagSyliusCmsPlugin:Media:Crud/_form.html.twig
+                    form: "@BitBagSyliusCmsPlugin/Media/Crud/_form.html.twig"
             index:
                 icon: file
     type: sylius.resource

--- a/src/Resources/config/routing/admin/page.yml
+++ b/src/Resources/config/routing/admin/page.yml
@@ -12,7 +12,7 @@ bitbag_sylius_cms_plugin_admin_page:
                 header: bitbag_sylius_cms_plugin.ui.pages_header
                 subheader: bitbag_sylius_cms_plugin.ui.pages_subheader
                 templates:
-                    form: BitBagSyliusCmsPlugin:Page:Crud/_form.html.twig
+                    form: "@BitBagSyliusCmsPlugin/Page/Crud/_form.html.twig"
             index:
                 icon: sticky note
     type: sylius.resource

--- a/src/Resources/config/routing/admin/section.yml
+++ b/src/Resources/config/routing/admin/section.yml
@@ -12,7 +12,7 @@ bitbag_sylius_cms_plugin_admin_section:
                 header: bitbag_sylius_cms_plugin.ui.sections_header
                 subheader: bitbag_sylius_cms_plugin.ui.sections_subheader
                 templates:
-                    form: BitBagSyliusCmsPlugin:Section:Crud/_form.html.twig
+                    form: "@BitBagSyliusCmsPlugin/Section/Crud/_form.html.twig"
             index:
                 icon: grid layout
     type: sylius.resource


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Some template path defined in route config is using legacy naming style. It prevents to override admin templates from a Symfony flex project.