### PR TITLE
Rollback SymfonyConfigTest and phpunit. Also fixes of constraint violations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "friendsofsymfony/ckeditor-bundle": "^1.1",
         "stefandoorn/sitemap-plugin": "^1.0",
         "sylius/sylius": "~1.3",
-        "matthiasnoback/symfony-config-test": "~3.1.0"
+        "matthiasnoback/symfony-config-test": "^3.1|^4.0"
     },
     "require-dev": {
         "behat/behat": "^3.4",
@@ -34,7 +34,7 @@
         "phpstan/phpstan-shim": "^0.10",
         "phpstan/phpstan-symfony": "^0.10",
         "phpstan/phpstan-webmozart-assert": "^0.10",
-        "phpunit/phpunit": "^6.5",
+        "phpunit/phpunit": "^6.0|^7.0",
         "sylius-labs/coding-standard": "^2.0",
         "symfony/browser-kit": "^3.4|^4.1",
         "symfony/debug-bundle": "^3.4|^4.1",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "friendsofsymfony/ckeditor-bundle": "^1.1",
         "stefandoorn/sitemap-plugin": "^1.0",
         "sylius/sylius": "~1.3",
-        "matthiasnoback/symfony-config-test": "^4.0"
+        "matthiasnoback/symfony-config-test": "~3.1.0"
     },
     "require-dev": {
         "behat/behat": "^3.4",
@@ -34,7 +34,7 @@
         "phpstan/phpstan-shim": "^0.10",
         "phpstan/phpstan-symfony": "^0.10",
         "phpstan/phpstan-webmozart-assert": "^0.10",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^6.5",
         "sylius-labs/coding-standard": "^2.0",
         "symfony/browser-kit": "^3.4|^4.1",
         "symfony/debug-bundle": "^3.4|^4.1",

--- a/src/Resources/config/doctrine/Block.orm.yml
+++ b/src/Resources/config/doctrine/Block.orm.yml
@@ -24,6 +24,7 @@ BitBag\SyliusCmsPlugin\Entity\Block:
                 joinColumns:
                     block_id:
                         referencedColumnName: id
+                        onDelete: CASCADE   
                 inverseJoinColumns:
                     section_id:
                         referencedColumnName: id
@@ -35,6 +36,7 @@ BitBag\SyliusCmsPlugin\Entity\Block:
                 joinColumns:
                     block_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     product_id:
                         referencedColumnName: id
@@ -46,6 +48,7 @@ BitBag\SyliusCmsPlugin\Entity\Block:
                 joinColumns:
                     block_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     channel_id:
                         referencedColumnName: id

--- a/src/Resources/config/doctrine/FrequentlyAskedQuestion.orm.yml
+++ b/src/Resources/config/doctrine/FrequentlyAskedQuestion.orm.yml
@@ -28,6 +28,7 @@ BitBag\SyliusCmsPlugin\Entity\FrequentlyAskedQuestion:
                 joinColumns:
                     faq_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     channel_id:
                         referencedColumnName: id

--- a/src/Resources/config/doctrine/Media.orm.yml
+++ b/src/Resources/config/doctrine/Media.orm.yml
@@ -38,6 +38,7 @@ BitBag\SyliusCmsPlugin\Entity\Media:
                 joinColumns:
                     media_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     section_id:
                         referencedColumnName: id
@@ -49,6 +50,7 @@ BitBag\SyliusCmsPlugin\Entity\Media:
                 joinColumns:
                     media_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     product_id:
                         referencedColumnName: id
@@ -60,6 +62,7 @@ BitBag\SyliusCmsPlugin\Entity\Media:
                 joinColumns:
                     block_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     channel_id:
                         referencedColumnName: id

--- a/src/Resources/config/doctrine/Page.orm.yml
+++ b/src/Resources/config/doctrine/Page.orm.yml
@@ -38,6 +38,7 @@ BitBag\SyliusCmsPlugin\Entity\Page:
                 joinColumns:
                     page_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     product_id:
                         referencedColumnName: id
@@ -49,6 +50,7 @@ BitBag\SyliusCmsPlugin\Entity\Page:
                 joinColumns:
                     block_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     section_id:
                         referencedColumnName: id


### PR DESCRIPTION
- As Sylius v1.3 comes with phpunit ^6.5 I find it more fitting that we keep the plugin usable out-of-the-box. Therefor I have downgraded SymfonyConfigTest to ~3.1 to keep this compatibility.
- When you add a section to a block, page or media you'll get a database constraint violation when deleting the block, page or media.

| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT