### PR TITLE
Links for media and blocks, update of validation for blocks and new route for custom template for medias

### DIFF
--- a/features/admin/adding_block.feature
+++ b/features/admin/adding_block.feature
@@ -38,13 +38,13 @@ Feature: Adding blocks
     Scenario: Trying to add block with blank data
         When I go to the create block page
         And I try to add it
-        Then I should be notified that "Code, Content" fields cannot be blank
+        Then I should be notified that "Code" fields cannot be blank
 
     @ui
     Scenario: Trying to add block with blank data
         When I go to the create block page
         And I try to add it
-        Then I should be notified that "Code, Content" fields cannot be blank
+        Then I should be notified that "Code" fields cannot be blank
 
     @ui
     Scenario: Trying to add block with too long data

--- a/spec/Entity/BlockTranslationSpec.php
+++ b/spec/Entity/BlockTranslationSpec.php
@@ -40,6 +40,9 @@ final class BlockTranslationSpec extends ObjectBehavior
         $this->setName('Escobar favorite quote');
         $this->getName()->shouldReturn('Escobar favorite quote');
 
+        $this->setLink('https://en.wikipedia.org/wiki/Pablo_Escobar');
+        $this->getLink()->shouldReturn('https://en.wikipedia.org/wiki/Pablo_Escobar');
+
         $this->setContent('Plata o plomo');
         $this->getContent()->shouldReturn('Plata o plomo');
     }

--- a/spec/Entity/MediaTranslationSpec.php
+++ b/spec/Entity/MediaTranslationSpec.php
@@ -47,5 +47,8 @@ final class MediaTranslationSpec extends ObjectBehavior
 
         $this->setAlt('video');
         $this->getAlt()->shouldReturn('video');
+
+        $this->setLink('https://github.com/Netimage/SyliusCmsPlugin');
+        $this->getLink()->shouldReturn('https://github.com/Netimage/SyliusCmsPlugin');
     }
 }

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -146,6 +146,16 @@ class Media implements MediaInterface
         $this->getMediaTranslation()->setAlt($alt);
     }
 
+    public function getLink(): ?string
+    {
+        return $this->getMediaTranslation()->getLink();
+    }
+
+    public function setLink(?string $link): void
+    {
+        $this->getMediaTranslation()->setLink($link);
+    }
+
     /**
      * @return MediaTranslationInterface|TranslationInterface
      */

--- a/src/Entity/MediaInterface.php
+++ b/src/Entity/MediaInterface.php
@@ -64,4 +64,8 @@ interface MediaInterface extends
     public function getAlt(): ?string;
 
     public function setAlt(?string $alt): void;
+
+    public function getLink(): ?string;
+
+    public function setLink(?string $link): void;
 }

--- a/src/Entity/MediaTranslation.php
+++ b/src/Entity/MediaTranslation.php
@@ -28,6 +28,9 @@ class MediaTranslation extends AbstractTranslation implements MediaTranslationIn
     /** @var string */
     protected $alt;
 
+    /** @var string */
+    protected $link;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -61,5 +64,15 @@ class MediaTranslation extends AbstractTranslation implements MediaTranslationIn
     public function setAlt(?string $alt): void
     {
         $this->alt = $alt;
+    }
+
+    public function getLink(): ?string
+    {
+        return $this->link;
+    }
+
+    public function setLink(?string $link): void
+    {
+        $this->link = $link;
     }
 }

--- a/src/Entity/MediaTranslationInterface.php
+++ b/src/Entity/MediaTranslationInterface.php
@@ -28,4 +28,8 @@ interface MediaTranslationInterface extends ResourceInterface, TranslationInterf
     public function getAlt(): ?string;
 
     public function setAlt(?string $alt): void;
+
+    public function getLink(): ?string;
+
+    public function setLink(?string $link): void;
 }

--- a/src/Fixture/Factory/MediaFixtureFactory.php
+++ b/src/Fixture/Factory/MediaFixtureFactory.php
@@ -104,6 +104,7 @@ final class MediaFixtureFactory implements FixtureFactoryInterface
             $mediaTranslation->setName($translation['name']);
             $mediaTranslation->setContent($translation['content']);
             $mediaTranslation->setAlt($translation['alt']);
+            $mediaTranslation->setLink($translation['link']);
             $media->addTranslation($mediaTranslation);
         }
 

--- a/src/Fixture/MediaFixture.php
+++ b/src/Fixture/MediaFixture.php
@@ -60,6 +60,7 @@ final class MediaFixture extends AbstractFixture
                                         ->scalarNode('name')->defaultNull()->end()
                                         ->scalarNode('content')->defaultNull()->end()
                                         ->scalarNode('alt')->defaultNull()->end()
+                                        ->scalarNode('link')->defaultNull()->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/src/Form/Type/Translation/BlockTranslationType.php
+++ b/src/Form/Type/Translation/BlockTranslationType.php
@@ -27,6 +27,10 @@ final class BlockTranslationType extends AbstractResourceType
                 'required' => false,
             ])
             ->add('content', WysiwygType::class)
+            ->add('link', TextType::class, [
+                'label' => 'bitbag_sylius_cms_plugin.ui.link',
+                'required' => false,
+            ])
         ;
     }
 

--- a/src/Form/Type/Translation/BlockTranslationType.php
+++ b/src/Form/Type/Translation/BlockTranslationType.php
@@ -26,10 +26,12 @@ final class BlockTranslationType extends AbstractResourceType
                 'label' => 'bitbag_sylius_cms_plugin.ui.name',
                 'required' => false,
             ])
-            ->add('content', WysiwygType::class)
             ->add('link', TextType::class, [
                 'label' => 'bitbag_sylius_cms_plugin.ui.link',
                 'required' => false,
+            ])
+            ->add('content', WysiwygType::class, [
+                'required' => false
             ])
         ;
     }

--- a/src/Form/Type/Translation/MediaTranslationType.php
+++ b/src/Form/Type/Translation/MediaTranslationType.php
@@ -30,6 +30,10 @@ final class MediaTranslationType extends AbstractResourceType
                 'label' => 'bitbag_sylius_cms_plugin.ui.alt',
                 'required' => false,
             ])
+            ->add('link', TextType::class, [
+                'label' => 'bitbag_sylius_cms_plugin.ui.link',
+                'required' => false,
+            ])
             ->add('content', WysiwygType::class, ['required' => false,])
         ;
     }

--- a/src/Resources/config/doctrine/MediaTranslation.orm.yml
+++ b/src/Resources/config/doctrine/MediaTranslation.orm.yml
@@ -20,3 +20,7 @@ BitBag\SyliusCmsPlugin\Entity\MediaTranslation:
             column: alt
             type: text
             nullable: true
+        link:
+            column: link
+            type: text
+            nullable: true

--- a/src/Resources/config/routing/shop/media.yml
+++ b/src/Resources/config/routing/shop/media.yml
@@ -10,6 +10,19 @@ bitbag_sylius_cms_plugin_shop_media_render:
                     - $code
                     - "expr:service('sylius.context.channel').getChannel().getCode()"
 
+bitbag_sylius_cms_plugin_shop_media_render_template:
+    path: /media-template/{code}
+    methods: [GET]
+    defaults:
+        _controller: bitbag_sylius_cms_plugin.controller.media:showAction
+        _sylius:
+            template: $template
+            repository:
+                method: findOneEnabledByCode
+                arguments:
+                - $code
+                - "expr:service('sylius.context.channel').getChannel().getCode()"
+
 bitbag_sylius_cms_plugin_shop_media_download:
     path: /media/download/{code}
     methods: [GET]

--- a/src/Resources/config/validation/BlockTranslation.yml
+++ b/src/Resources/config/validation/BlockTranslation.yml
@@ -7,10 +7,8 @@ BitBag\SyliusCmsPlugin\Entity\BlockTranslation:
                 minMessage: bitbag_sylius_cms_plugin.block.name.min_length
                 maxMessage: bitbag_sylius_cms_plugin.block.name.max_length
                 groups: ['bitbag']
+
         content:
-            - NotBlank:
-                message: bitbag_sylius_cms_plugin.block.content.not_blank
-                groups: ['bitbag_content']
             - Length:
                 min: 2
                 minMessage: bitbag_sylius_cms_plugin.block.content.min_length

--- a/src/Resources/config/validation/BlockTranslation.yml
+++ b/src/Resources/config/validation/BlockTranslation.yml
@@ -7,7 +7,13 @@ BitBag\SyliusCmsPlugin\Entity\BlockTranslation:
                 minMessage: bitbag_sylius_cms_plugin.block.name.min_length
                 maxMessage: bitbag_sylius_cms_plugin.block.name.max_length
                 groups: ['bitbag']
-
+        link:
+            - Length:
+                min: 2
+                max: 250
+                minMessage: bitbag_sylius_cms_plugin.block.link.min_length
+                maxMessage: bitbag_sylius_cms_plugin.block.link.max_length
+                groups: ['bitbag']
         content:
             - Length:
                 min: 2

--- a/src/Resources/config/validation/MediaTranslation.yml
+++ b/src/Resources/config/validation/MediaTranslation.yml
@@ -14,6 +14,13 @@ BitBag\SyliusCmsPlugin\Entity\MediaTranslation:
                 minMessage: bitbag_sylius_cms_plugin.media.alt.min_length
                 maxMessage: bitbag_sylius_cms_plugin.media.alt.max_length
                 groups: [bitbag]
+        link:
+            - Length:
+                min: 2
+                max: 250
+                minMessage: bitbag_sylius_cms_plugin.media.link.min_length
+                maxMessage: bitbag_sylius_cms_plugin.media.link.max_length
+                groups: [bitbag]
         content:
             - Length:
                 min: 2

--- a/src/Resources/translations/validators.en.yml
+++ b/src/Resources/translations/validators.en.yml
@@ -11,6 +11,9 @@ bitbag_sylius_cms_plugin:
         name:
             min_length: Name must be at least {{ limit }} characters long.
             max_length: Name can not be longer than {{ limit }} characters.
+        link:
+            min_length: Link must be at least {{ limit }} characters long.
+            max_length: Link can not be longer than {{ limit }} characters.
         content:
             not_blank: Content cannot be blank.
             min_length: Content must be at least {{ limit }} characters long.
@@ -80,6 +83,9 @@ bitbag_sylius_cms_plugin:
         alt:
             min_length: Alt must be at least {{ limit }} characters long.
             max_length: Alt can not be longer than {{ limit }} characters.
+        link:
+            min_length: Link must be at least {{ limit }} characters long.
+            max_length: Link can not be longer than {{ limit }} characters.
     import:
         not_blank: Import file cannot be blank.
         invalid_format: Upload a valid CSV import file.


### PR DESCRIPTION
- Added links to media-image: I wan't to create sections where I add media-images with "promotions" pictures that links to a page. But I also wan't to be able to add overlay content to that media-image.
- Added links to blocks: I guess that either blocks had links enabled before and got removed, or they never got implemented in the block form.
- Removed not-blank validation from blocks: Now when I added links to blocks I would like to create sections with link-blocks. Like columns with links in the footer of a website. Therefor I need the option to create blocks without any content.
- Added a route for media with variable template: I needed a way to get medias with a custom template.

| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT