### PR TITLE
Fix Page mapping to cascade delete product association

### DIFF
--- a/src/Resources/config/doctrine/Page.orm.yml
+++ b/src/Resources/config/doctrine/Page.orm.yml
@@ -38,6 +38,7 @@ BitBag\SyliusCmsPlugin\Entity\Page:
                 joinColumns:
                     page_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     product_id:
                         referencedColumnName: id
@@ -49,6 +50,7 @@ BitBag\SyliusCmsPlugin\Entity\Page:
                 joinColumns:
                     block_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     section_id:
                         referencedColumnName: id


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

A page could not be deleted if linked to a product or a section, resulting in a FK error thrown by the DB.

I noticed an invalid name for the join column of the section association (block_id instead of page_id, see line 51) but did not change it for BC