### PR TITLE
Fixed problem with innerJoin on translation that not exist

### DIFF
--- a/src/Repository/BlockRepository.php
+++ b/src/Repository/BlockRepository.php
@@ -21,8 +21,8 @@ class BlockRepository extends EntityRepository implements BlockRepositoryInterfa
     public function createListQueryBuilder(string $localeCode): QueryBuilder
     {
         return $this->createQueryBuilder('o')
-            ->innerJoin('o.translations', 'translation')
-            ->where('translation.locale = :localeCode')
+            ->addSelect('translation')
+            ->leftJoin('o.translations', 'translation', 'WITH', 'translation.locale = :localeCode')
             ->setParameter('localeCode', $localeCode)
         ;
     }

--- a/src/Repository/FrequentlyAskedQuestionRepository.php
+++ b/src/Repository/FrequentlyAskedQuestionRepository.php
@@ -18,12 +18,12 @@ use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 
 final class FrequentlyAskedQuestionRepository extends EntityRepository implements FrequentlyAskedQuestionRepositoryInterface
 {
-    public function createListQueryBuilder(string $locale): QueryBuilder
+    public function createListQueryBuilder(string $localeCode): QueryBuilder
     {
         return $this->createQueryBuilder('o')
-            ->innerJoin('o.translations', 'translation')
-            ->where('translation.locale = :locale')
-            ->setParameter('locale', $locale)
+            ->addSelect('translation')
+            ->leftJoin('o.translations', 'translation', 'WITH', 'translation.locale = :localeCode')
+            ->setParameter('localeCode', $localeCode)
         ;
     }
 

--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -19,12 +19,12 @@ use Sylius\Component\Core\Model\ProductInterface;
 
 class PageRepository extends EntityRepository implements PageRepositoryInterface
 {
-    public function createListQueryBuilder(string $locale): QueryBuilder
+    public function createListQueryBuilder(string $localeCode): QueryBuilder
     {
         return $this->createQueryBuilder('o')
-            ->innerJoin('o.translations', 'translation')
-            ->where('translation.locale = :locale')
-            ->setParameter('locale', $locale)
+            ->addSelect('translation')
+            ->leftJoin('o.translations', 'translation', 'WITH', 'translation.locale = :localeCode')
+            ->setParameter('localeCode', $localeCode)
         ;
     }
 

--- a/src/Repository/PageRepositoryInterface.php
+++ b/src/Repository/PageRepositoryInterface.php
@@ -19,7 +19,7 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 interface PageRepositoryInterface extends RepositoryInterface
 {
-    public function createListQueryBuilder(string $locale): QueryBuilder;
+    public function createListQueryBuilder(string $localeCode): QueryBuilder;
 
     public function findEnabled(bool $enabled): array;
 

--- a/src/Repository/SectionRepository.php
+++ b/src/Repository/SectionRepository.php
@@ -18,10 +18,12 @@ use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 
 class SectionRepository extends EntityRepository implements SectionRepositoryInterface
 {
-    public function createListQueryBuilder(): QueryBuilder
+    public function createListQueryBuilder(string $localeCode): QueryBuilder
     {
         return $this->createQueryBuilder('o')
-            ->leftJoin('o.translations', 'translation')
+            ->addSelect('translation')
+            ->leftJoin('o.translations', 'translation', 'WITH', 'translation.locale = :localeCode')
+            ->setParameter('localeCode', $localeCode)
         ;
     }
 

--- a/src/Repository/SectionRepositoryInterface.php
+++ b/src/Repository/SectionRepositoryInterface.php
@@ -18,7 +18,7 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 interface SectionRepositoryInterface extends RepositoryInterface
 {
-    public function createListQueryBuilder(): QueryBuilder;
+    public function createListQueryBuilder(string $localeCode): QueryBuilder;
 
     public function findByNamePart(string $phrase, ?string $locale = null): array;
 

--- a/src/Resources/config/grids/admin/block.yml
+++ b/src/Resources/config/grids/admin/block.yml
@@ -16,13 +16,6 @@ sylius_grid:
                     type: string
                     label: sylius.ui.code
                     sortable: ~
-                content:
-                    type: twig
-                    label: sylius.ui.content
-                    path: .
-                    sortable: translation.content
-                    options:
-                        template: "@BitBagSyliusCmsPlugin/Grid/Field/content.html.twig"
                 enabled:
                     type: twig
                     label: sylius.ui.enabled

--- a/src/Resources/config/grids/admin/section.yml
+++ b/src/Resources/config/grids/admin/section.yml
@@ -7,6 +7,7 @@ sylius_grid:
                     class: "%bitbag_sylius_cms_plugin.model.section.class%"
                     repository:
                         method: createListQueryBuilder
+                        arguments: ["%locale%"]
             sorting:
                 code: asc
             limits: [10, 25, 50]

--- a/src/Resources/views/Grid/Field/sections.html.twig
+++ b/src/Resources/views/Grid/Field/sections.html.twig
@@ -1,3 +1,3 @@
 {% for section in data.sections %}
-    {{ section.name }}{{ loop.last ? "" : ", " }}
+    <span class="ui label">{{ section.code }}</span>
 {% endfor %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no/
| Deprecations?   | no
| License         | MIT

- Fixed an issue in admin with getting being able to see elements without an existing for locale of current admin user.
- Also removed the `content` field from the block overview. If you would have a large text, it would screw up the whole admin page.
