### PR TITLE
Blocktaxons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "league/csv": "^9.0",
         "friendsofsymfony/ckeditor-bundle": "^1.1",
         "stefandoorn/sitemap-plugin": "^1.0",
-        "sylius/sylius": "~1.4.0",
+        "sylius/sylius": "~1.3",
         "sensiolabs/security-checker": "^5.0"
     },
     "require-dev": {

--- a/src/Assigner/TaxonsAssigner.php
+++ b/src/Assigner/TaxonsAssigner.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.shop and write us
+ * an email on mikolaj.krol@bitbag.pl.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusCmsPlugin\Assigner;
+
+use BitBag\SyliusCmsPlugin\Entity\TaxonAwareInterface;
+use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+
+final class TaxonsAssigner implements TaxonsAssignerInterface
+{
+    /** @var TaxonRepositoryInterface */
+    private $taxonRepository;
+
+    public function __construct(TaxonRepositoryInterface $taxonRepository)
+    {
+        $this->taxonRepository = $taxonRepository;
+    }
+
+    public function assign(TaxonAwareInterface $taxonAware, array $taxonCodes): void
+    {
+        foreach ($taxonCodes as $taxonCode) {
+            /** @var TaxonInterface $taxon */
+            $taxon = $this->taxonRepository->findOneBy(['code' => $taxonCode]);
+
+            if (null !== $taxon) {
+                $taxonAware->addTaxon($taxon);
+            }
+        }
+    }
+}

--- a/src/Assigner/TaxonsAssignerInterface.php
+++ b/src/Assigner/TaxonsAssignerInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.shop and write us
+ * an email on mikolaj.krol@bitbag.pl.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusCmsPlugin\Assigner;
+
+use BitBag\SyliusCmsPlugin\Entity\TaxonAwareInterface;
+
+interface TaxonsAssignerInterface
+{
+    public function assign(TaxonAwareInterface $taxonAware, array $taxonCodes): void;
+}

--- a/src/Controller/Action/Admin/TaxonSearchAction.php
+++ b/src/Controller/Action/Admin/TaxonSearchAction.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.shop and write us
+ * an email on mikolaj.krol@bitbag.pl.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusCmsPlugin\Controller\Action\Admin;
+
+use FOS\RestBundle\View\View;
+use FOS\RestBundle\View\ViewHandler;
+use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class TaxonSearchAction
+{
+    /** @var TaxonRepositoryInterface */
+    private $taxonRepository;
+
+    /** @var ViewHandler */
+    private $viewHandler;
+
+    public function __construct(TaxonRepositoryInterface $taxonRepository, ViewHandler $viewHandler)
+    {
+        $this->taxonRepository = $taxonRepository;
+        $this->viewHandler = $viewHandler;
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $product = $this->taxonRepository->findByNamePart($request->get('phrase', ''));
+        $view = View::create($product);
+
+        $this->viewHandler->setExclusionStrategyGroups(['Autocomplete']);
+        $view->getContext()->enableMaxDepth();
+
+        return $this->viewHandler->handle($view);
+    }
+}

--- a/src/Entity/Block.php
+++ b/src/Entity/Block.php
@@ -21,6 +21,7 @@ class Block implements BlockInterface
     use ToggleableTrait;
     use SectionableTrait;
     use ProductsAwareTrait;
+    use TaxonAwareTrait;
     use ChannelsAwareTrait;
     use TranslatableTrait {
         __construct as protected initializeTranslationsCollection;
@@ -31,6 +32,7 @@ class Block implements BlockInterface
         $this->initializeTranslationsCollection();
         $this->initializeSectionsCollection();
         $this->initializeProductsCollection();
+        $this->initializeTaxonCollection();
         $this->initializeChannelsCollection();
     }
 

--- a/src/Entity/BlockInterface.php
+++ b/src/Entity/BlockInterface.php
@@ -22,6 +22,7 @@ interface BlockInterface extends
     TranslatableInterface,
     ToggleableInterface,
     ProductsAwareInterface,
+    TaxonAwareInterface,
     SectionableInterface,
     ChannelsAwareInterface,
     ContentableInterface

--- a/src/Entity/TaxonAwareInterface.php
+++ b/src/Entity/TaxonAwareInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.shop and write us
+ * an email on mikolaj.krol@bitbag.pl.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusCmsPlugin\Entity;
+
+use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Core\Model\TaxonInterface;
+
+interface TaxonAwareInterface
+{
+    public function initializeTaxonCollection(): void;
+
+    /**
+     * @return Collection|TaxonInterface[]
+     */
+    public function getTaxons(): Collection;
+
+    public function hasTaxon(TaxonInterface $taxon): bool;
+
+    public function addTaxon(TaxonInterface $taxon): void;
+
+    public function removeTaxon(TaxonInterface $taxon): void;
+}

--- a/src/Entity/TaxonAwareTrait.php
+++ b/src/Entity/TaxonAwareTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.shop and write us
+ * an email on mikolaj.krol@bitbag.pl.
+ */
+
+declare(strict_types=1);
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.shop and write us
+ * an email on mikolaj.krol@bitbag.pl.
+ */
+
+namespace BitBag\SyliusCmsPlugin\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Core\Model\TaxonInterface;
+
+trait TaxonAwareTrait
+{
+    /** @var Collection|TaxonInterface[] */
+    protected $taxonomies;
+
+    public function initializeTaxonCollection(): void
+    {
+        $this->taxonomies = new ArrayCollection();
+    }
+
+    public function getTaxons(): Collection
+    {
+        return $this->taxonomies;
+    }
+
+    public function hasTaxon(TaxonInterface $taxon): bool
+    {
+        return $this->taxonomies->contains($taxon);
+    }
+
+    public function addTaxon(TaxonInterface $taxon): void
+    {
+        if (false === $this->hasTaxon($taxon)) {
+            $this->taxonomies->add($taxon);
+        }
+    }
+
+    public function removeTaxon(TaxonInterface $taxon): void
+    {
+        if (true === $this->hasTaxon($taxon)) {
+            $this->taxonomies->removeElement($taxon);
+        }
+    }
+}

--- a/src/Fixture/BlockFixture.php
+++ b/src/Fixture/BlockFixture.php
@@ -49,6 +49,7 @@ final class BlockFixture extends AbstractFixture
                             ->booleanNode('enabled')->defaultTrue()->end()
                             ->integerNode('products')->defaultNull()->end()
                             ->arrayNode('productCodes')->scalarPrototype()->end()->end()
+                            ->arrayNode('taxons')->scalarPrototype()->end()->end()
                             ->arrayNode('sections')->scalarPrototype()->end()->end()
                             ->arrayNode('channels')->scalarPrototype()->end()->end()
                             ->arrayNode('translations')

--- a/src/Fixture/Factory/BlockFixtureFactory.php
+++ b/src/Fixture/Factory/BlockFixtureFactory.php
@@ -15,6 +15,7 @@ namespace BitBag\SyliusCmsPlugin\Fixture\Factory;
 use BitBag\SyliusCmsPlugin\Assigner\ChannelsAssignerInterface;
 use BitBag\SyliusCmsPlugin\Assigner\ProductsAssignerInterface;
 use BitBag\SyliusCmsPlugin\Assigner\SectionsAssignerInterface;
+use BitBag\SyliusCmsPlugin\Assigner\TaxonsAssignerInterface;
 use BitBag\SyliusCmsPlugin\Entity\BlockInterface;
 use BitBag\SyliusCmsPlugin\Entity\BlockTranslationInterface;
 use BitBag\SyliusCmsPlugin\Repository\BlockRepositoryInterface;
@@ -46,6 +47,9 @@ final class BlockFixtureFactory implements FixtureFactoryInterface
     /** @var ProductsAssignerInterface */
     private $productsAssigner;
 
+    /** @var TaxonsAssignerInterface */
+    private $taxonsAssigner;
+
     /** @var SectionsAssignerInterface */
     private $sectionsAssigner;
 
@@ -60,6 +64,7 @@ final class BlockFixtureFactory implements FixtureFactoryInterface
         ChannelContextInterface $channelContext,
         LocaleContextInterface $localeContext,
         ProductsAssignerInterface $productsAssigner,
+        TaxonsAssignerInterface $taxonsAssigner,
         SectionsAssignerInterface $sectionsAssigner,
         ChannelsAssignerInterface $channelAssigner
     ) {
@@ -70,6 +75,7 @@ final class BlockFixtureFactory implements FixtureFactoryInterface
         $this->channelContext = $channelContext;
         $this->localeContext = $localeContext;
         $this->productsAssigner = $productsAssigner;
+        $this->taxonsAssigner = $taxonsAssigner;
         $this->sectionsAssigner = $sectionsAssigner;
         $this->channelAssigner = $channelAssigner;
     }
@@ -106,6 +112,7 @@ final class BlockFixtureFactory implements FixtureFactoryInterface
 
         $this->sectionsAssigner->assign($block, $blockData['sections']);
         $this->productsAssigner->assign($block, $blockData['productCodes']);
+        $this->taxonsAssigner->assign($block, $blockData['taxons']);
         $this->channelAssigner->assign($block, $blockData['channels']);
 
         $block->setCode($code);

--- a/src/Form/Type/BlockType.php
+++ b/src/Form/Type/BlockType.php
@@ -18,6 +18,7 @@ use Sylius\Bundle\ChannelBundle\Form\Type\ChannelChoiceType;
 use Sylius\Bundle\ProductBundle\Form\Type\ProductAutocompleteChoiceType;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Bundle\ResourceBundle\Form\Type\ResourceTranslationsType;
+use Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonAutocompleteChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -44,6 +45,10 @@ final class BlockType extends AbstractResourceType
             ])
             ->add('products', ProductAutocompleteChoiceType::class, [
                 'label' => 'bitbag_sylius_cms_plugin.ui.products',
+                'multiple' => true,
+            ])
+            ->add('taxons', TaxonAutocompleteChoiceType::class, [
+                'label' => 'bitbag_sylius_cms_plugin.ui.taxons',
                 'multiple' => true,
             ])
             ->add('channels', ChannelChoiceType::class, [

--- a/src/Repository/TaxonRepository.php
+++ b/src/Repository/TaxonRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.shop and write us
+ * an email on mikolaj.krol@bitbag.pl.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusCmsPlugin\Repository;
+
+use Doctrine\ORM\QueryBuilder;
+use Sylius\Bundle\TaxonomyBundle\Doctrine\ORM\TaxonRepository as BaseTaxonRepository;
+
+class TaxonRepository extends BaseTaxonRepository implements TaxonRepositoryInterface
+{
+    public function findByNamePart(string $phrase, ?string $locale = null): array
+    {
+        return $this->createTranslationBasedQueryBuilder($locale)
+            ->andWhere('translation.name LIKE :name')
+            ->setParameter('name', '%' . $phrase . '%')
+            ->getQuery()
+            ->getResult()
+            ;
+    }
+
+    private function createTranslationBasedQueryBuilder(?string $locale = null): QueryBuilder
+    {
+        $queryBuilder = $this->createQueryBuilder('o')
+            ->addSelect('translation')
+            ->leftJoin('o.translations', 'translation')
+        ;
+
+        if (null !== $locale) {
+            $queryBuilder
+                ->andWhere('translation.locale = :locale')
+                ->setParameter('locale', $locale)
+            ;
+        }
+
+        return $queryBuilder;
+    }
+}

--- a/src/Repository/TaxonRepositoryInterface.php
+++ b/src/Repository/TaxonRepositoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file has been created by developers from BitBag.
+ * Feel free to contact us once you face any issues or want to start
+ * another great project.
+ * You can find more information about us on https://bitbag.shop and write us
+ * an email on mikolaj.krol@bitbag.pl.
+ */
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusCmsPlugin\Repository;
+
+use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface as BaseTaxonRepositoryInterface;
+
+interface TaxonRepositoryInterface extends BaseTaxonRepositoryInterface
+{
+    public function findByNamePart(string $phrase, ?string $locale = null): array;
+}

--- a/src/Resources/config/doctrine/Block.orm.yml
+++ b/src/Resources/config/doctrine/Block.orm.yml
@@ -24,6 +24,7 @@ BitBag\SyliusCmsPlugin\Entity\Block:
                 joinColumns:
                     block_id:
                         referencedColumnName: id
+                        onDelete: CASCADE
                 inverseJoinColumns:
                     section_id:
                         referencedColumnName: id
@@ -39,6 +40,21 @@ BitBag\SyliusCmsPlugin\Entity\Block:
                     product_id:
                         referencedColumnName: id
                         onDelete: CASCADE
+
+
+        taxonomies:
+            targetEntity: Sylius\Component\Taxonomy\Model\TaxonInterface
+            joinTable:
+                name: bitbag_cms_block_taxonomies
+                joinColumns:
+                    block_id:
+                        referencedColumnName: id
+                        onDelete: CASCADE
+                inverseJoinColumns:
+                    taxon_id:
+                        referencedColumnName: id
+                        onDelete: CASCADE
+
         channels:
             targetEntity: Sylius\Component\Channel\Model\ChannelInterface
             joinTable:

--- a/src/Resources/config/routing/admin.yml
+++ b/src/Resources/config/routing/admin.yml
@@ -16,6 +16,9 @@ bitbag_sylius_cms_plugin_admin_media:
 bitbag_sylius_cms_plugin_admin_product:
     resource: "@BitBagSyliusCmsPlugin/Resources/config/routing/admin/product.yml"
 
+bitbag_sylius_cms_plugin_admin_taxon:
+    resource: "@BitBagSyliusCmsPlugin/Resources/config/routing/admin/taxon.yml"
+
 bitbag_sylius_cms_plugin_admin_locale:
     resource: "@BitBagSyliusCmsPlugin/Resources/config/routing/admin/locale.yml"
 

--- a/src/Resources/config/routing/admin/taxon.yml
+++ b/src/Resources/config/routing/admin/taxon.yml
@@ -1,0 +1,6 @@
+bitbag_sylius_cms_plugin_admin_ajax_taxon_by_name_phrase:
+    path: /ajax/taxon/search-by-name
+    methods: [GET]
+    defaults:
+        _format: json
+        _controller: bitbag_sylius_cms_plugin.controller.action.admin.taxon_search

--- a/src/Resources/config/services/assigner.yml
+++ b/src/Resources/config/services/assigner.yml
@@ -9,6 +9,10 @@ services:
         arguments:
             - "@sylius.repository.product"
 
+    bitbag_sylius_cms_plugin.assigner.taxons:
+        class: BitBag\SyliusCmsPlugin\Assigner\TaxonsAssigner
+        arguments:
+            - "@sylius.repository.taxon"
 
     bitbag_sylius_cms_plugin.assigner.sections:
         class: BitBag\SyliusCmsPlugin\Assigner\SectionsAssigner

--- a/src/Resources/config/services/controller.yml
+++ b/src/Resources/config/services/controller.yml
@@ -12,6 +12,13 @@ services:
             - "@bitbag_sylius_cms_plugin.repository.product"
             - "@fos_rest.view_handler.default"
 
+    bitbag_sylius_cms_plugin.controller.action.admin.taxon_search:
+        class: BitBag\SyliusCmsPlugin\Controller\Action\Admin\TaxonSearchAction
+        public: true
+        arguments:
+            - "@bitbag_sylius_cms_plugin.repository.taxon"
+            - "@fos_rest.view_handler.default"
+
     bitbag_sylius_cms_plugin.controller.action.admin.import_data:
         class: BitBag\SyliusCmsPlugin\Controller\Action\Admin\ImportDataAction
         public: true

--- a/src/Resources/config/services/fixture.yml
+++ b/src/Resources/config/services/fixture.yml
@@ -44,6 +44,7 @@ services:
             - "@sylius.context.channel"
             - "@sylius.context.locale"
             - "@bitbag_sylius_cms_plugin.assigner.products"
+            - "@bitbag_sylius_cms_plugin.assigner.taxons"
             - "@bitbag_sylius_cms_plugin.assigner.sections"
             - "@bitbag_sylius_cms_plugin.assigner.channels"
 

--- a/src/Resources/config/services/repository.yml
+++ b/src/Resources/config/services/repository.yml
@@ -1,4 +1,13 @@
 services:
     bitbag_sylius_cms_plugin.repository.product:
         class: BitBag\SyliusCmsPlugin\Repository\ProductRepository
+        arguments:
+            - "@sylius.manager.product"
+            - "@=service('sylius.manager.product').getClassMetadata('Sylius\\\\Component\\\\Core\\\\Model\\\\Product')"
+
+    bitbag_sylius_cms_plugin.repository.taxon:
+        class: BitBag\SyliusCmsPlugin\Repository\TaxonRepository
+        arguments:
+            - "@sylius.manager.taxon"
+            - "@=service('sylius.manager.taxon').getClassMetadata('Sylius\\\\Component\\\\Core\\\\Model\\\\Taxon')"
 

--- a/src/Resources/config/services/repository.yml
+++ b/src/Resources/config/services/repository.yml
@@ -1,13 +1,8 @@
 services:
     bitbag_sylius_cms_plugin.repository.product:
         class: BitBag\SyliusCmsPlugin\Repository\ProductRepository
-        arguments:
-            - "@sylius.manager.product"
-            - "@=service('sylius.manager.product').getClassMetadata('Sylius\\\\Component\\\\Core\\\\Model\\\\Product')"
+        parent: sylius.repository.taxon
 
     bitbag_sylius_cms_plugin.repository.taxon:
         class: BitBag\SyliusCmsPlugin\Repository\TaxonRepository
-        arguments:
-            - "@sylius.manager.taxon"
-            - "@=service('sylius.manager.taxon').getClassMetadata('Sylius\\\\Component\\\\Core\\\\Model\\\\Taxon')"
-
+        parent: sylius.repository.taxon

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -10,6 +10,7 @@ bitbag_sylius_cms_plugin:
         pages_header: Pages
         pages_subheader: Manage your pages
         products: Products
+        taxons: Taxons
         page_related_products: Page related products
         name: Name
         slug: Slug

--- a/src/Resources/views/Block/Crud/_form.html.twig
+++ b/src/Resources/views/Block/Crud/_form.html.twig
@@ -10,6 +10,7 @@
             {{ form_row(form.code) }}
             {{ form_row(form.enabled) }}
             {{ form_row(form.products) }}
+            {{ form_row(form.taxons) }}
             {{ form_row(form.sections) }}
             {{ form_row(form.channels) }}
 

--- a/src/Resources/views/Form/theme.html.twig
+++ b/src/Resources/views/Form/theme.html.twig
@@ -7,3 +7,7 @@
 {% block sylius_product_autocomplete_choice_row %}
     {{ form_row(form, {'remote_url': path('bitbag_sylius_cms_plugin_admin_ajax_product_by_name_phrase'), 'load_edit_url': path('sylius_admin_ajax_product_by_code')}) }}
 {% endblock %}
+
+{% block sylius_taxon_autocomplete_choice_row %}
+    {{ form_row(form, {'remote_url': path('bitbag_sylius_cms_plugin_admin_ajax_taxon_by_name_phrase'), 'load_edit_url': path('sylius_admin_ajax_taxon_by_code')}) }}
+{% endblock %}

--- a/tests/Application/.env
+++ b/tests/Application/.env
@@ -12,7 +12,7 @@ APP_SECRET=EDITME
 # Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # For a sqlite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
 # Set "serverVersion" to your server version to avoid edge-case exceptions and extra database calls
-DATABASE_URL=sqlite:///%kernel.project_dir%/var/data.db
+DATABASE_URL=mysql://root:pass@localhost/sylius_bitbag_cms_plugin_test
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/swiftmailer-bundle ###

--- a/tests/Application/.env.test
+++ b/tests/Application/.env.test
@@ -2,4 +2,4 @@ APP_ENV=test
 APP_SECRET='ch4mb3r0f5ecr3ts'
 
 KERNEL_CLASS='Tests\BitBag\SyliusCmsPlugin\Application\Kernel'
-DATABASE_URL='sqlite:///%kernel.project_dir%/var/data.db'
+DATABASE_URL=mysql://root:pass@localhost/sylius_bitbag_cms_plugin_test

--- a/tests/Application/config/packages/test/monolog.yaml
+++ b/tests/Application/config/packages/test/monolog.yaml
@@ -4,3 +4,4 @@ monolog:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: error
+            include_stacktraces: true


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

## Related taxons to block
Added the feature for adding related taxons to block. This is usefull for some like if you wan't to create sliders for selected taxons on the homepage.
```{% for taxon in block.taxons %}
    <h3 class="section-headline">{{ block.name }}</h3>
    <div class="sub">{{ block.content|raw }}</div>
    {{ render(url('sylius_shop_partial_product_index_by_taxon_code', {'code': taxon.code, 'count': 16, 'template': '@SyliusShop/Product/Slider/_productSlider.html.twig'})) }}
{% endfor %}```

## Removed constraint for Sylius v1.4
I can not install the bitbag cms plugin for my v1.3 app anymore, and I believe there is no reason to constraint it to v1.4, as the plugin seem to work fine with my 1.3 app.

## Fixed a mistake I made
I removed the parent from the repositories as it seemed to not break anything, it did tho, so I reverted it.