### PR TITLE
Do not filter on type field because it doesn't exist

### DIFF
--- a/src/Resources/config/grids/admin/block.yml
+++ b/src/Resources/config/grids/admin/block.yml
@@ -41,7 +41,7 @@ sylius_grid:
                     type: string
                     label: sylius.ui.search
                     options:
-                        fields: [code, type]
+                        fields: [code]
                 enabled:
                     type: boolean
             actions:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

It's a one line fix.

I just removed the `type` field in filters because blocks don't have type… it was leading to broken filters in admin.

Cheers!