### PR TITLE
Fix conflict with import/export plugin.

### DIFF
--- a/doc/importing-resources.md
+++ b/doc/importing-resources.md
@@ -181,7 +181,7 @@ final class ProductImporter extends AbstractImporter implements ProductImporterI
             - "@validator"
             - "@doctrine.orm.entity_manager"
         tags:
-            - { name: bitbag.importer }
+            - { name: bitbag.cmsplugin.importer }
 ```
 
 5. :tada:

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -60,7 +60,6 @@ $ yarn run gulp
 $ bin/console assets:install public -e test
 $ bin/console doctrine:schema:create -e test
 $ bin/console server:run 127.0.0.1:8080 -d public -e test
-$ elasticsearch
 $ open http://localhost:8080
 $ vendor/bin/behat
 $ vendor/bin/phpspec run

--- a/src/DependencyInjection/Compiler/ImporterCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ImporterCompilerPass.php
@@ -19,6 +19,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class ImporterCompilerPass implements CompilerPassInterface
 {
+    private const TAG_ID = 'bitbag.cmsplugin.importer';
+
     public function process(ContainerBuilder $container): void
     {
         if (!$container->has('bitbag_sylius_cms_plugin.importer.chain')) {
@@ -27,10 +29,10 @@ final class ImporterCompilerPass implements CompilerPassInterface
 
         $container
             ->registerForAutoconfiguration(ImporterInterface::class)
-            ->addTag('bitbag.importer')
+            ->addTag(self::TAG_ID)
         ;
 
-        $taggedServices = $container->findTaggedServiceIds('bitbag.importer');
+        $taggedServices = $container->findTaggedServiceIds(self::TAG_ID);
         $definition = $container->findDefinition('bitbag_sylius_cms_plugin.importer.chain');
 
         foreach ($taggedServices as $id => $tags) {

--- a/src/Resources/config/services/importer.yml
+++ b/src/Resources/config/services/importer.yml
@@ -16,7 +16,7 @@ services:
             - "@validator"
             - "@doctrine.orm.entity_manager"
         tags:
-            - { name: bitbag.importer }
+            - { name: bitbag.cmsplugin.importer }
 
     bitbag_sylius_cms_plugin.importer.block:
         class: BitBag\SyliusCmsPlugin\Importer\BlockImporter
@@ -29,7 +29,7 @@ services:
             - "@validator"
             - "@doctrine.orm.entity_manager"
         tags:
-            - { name: bitbag.importer }
+            - { name: bitbag.cmsplugin.importer }
 
     bitbag_sylius_cms_plugin.importer.media:
         class: BitBag\SyliusCmsPlugin\Importer\MediaImporter
@@ -41,4 +41,4 @@ services:
             - "@validator"
             - "@doctrine.orm.entity_manager"
         tags:
-            - { name: bitbag.importer }
+            - { name: bitbag.cmsplugin.importer }


### PR DESCRIPTION
Import/export plugin use the same tag name as `bitbag.importer` but the different interface for importer classes.
After running `bin/console cache:clear` container build fail because compiler pass gets all services with tag name bitbag.importer.
In this fix the tag name `bitbag.importer` is replaced to `bitbag.cmsplugin.importer`

| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update UPGRADE-*.md file -->
| License         | MIT
