### PR TITLE
Add Section filter to Pages grid

### DIFF
--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -24,6 +24,7 @@ class PageRepository extends EntityRepository implements PageRepositoryInterface
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
             ->leftJoin('o.translations', 'translation', 'WITH', 'translation.locale = :localeCode')
+            ->leftJoin('o.sections', 'sections')
             ->setParameter('localeCode', $localeCode)
         ;
     }

--- a/src/Resources/config/grids/admin/page.yml
+++ b/src/Resources/config/grids/admin/page.yml
@@ -42,6 +42,15 @@ sylius_grid:
                     label: sylius.ui.search
                     options:
                         fields: [code]
+                sections:
+                    type: entity
+                    label: bitbag_sylius_cms_plugin.ui.sections
+                    form_options:
+                        class: "%bitbag_sylius_cms_plugin.model.section.class%"
+                        choice_label: name
+                        choice_value: code
+                    options:
+                        fields: [sections.code]
             actions:
                 main:
                     import:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This feature adds a Section filter to the Pages grid by default.