### PR TITLE
Added missing template option to override media rendering templates.

### DIFF
--- a/src/Controller/MediaController.php
+++ b/src/Controller/MediaController.php
@@ -40,9 +40,15 @@ final class MediaController extends ResourceController
 
         $this->eventDispatcher->dispatch(ResourceActions::SHOW, $configuration, $media);
 
-        $mediaProviderResolver = $this->get('bitbag_sylius_cms_plugin.resolver.media_provider');
+        $mediaProvider = $this->get('bitbag_sylius_cms_plugin.resolver.media_provider')
+            ->resolveProvider($media);
 
-        return new Response($mediaProviderResolver->resolveProvider($media)->render($media));
+        $template = $request->get('template');
+        if (null !== $template) {
+            $mediaProvider->setTemplate($template);
+        }
+
+        return new Response($mediaProvider->render($media));
     }
 
     public function downloadMediaAction(Request $request): Response

--- a/src/MediaProvider/GenericProvider.php
+++ b/src/MediaProvider/GenericProvider.php
@@ -42,6 +42,13 @@ final class GenericProvider implements ProviderInterface
         $this->pathPrefix = $pathPrefix;
     }
 
+    public function setTemplate(string $string): ProviderInterface
+    {
+        $this->template = $string;
+
+        return $this;
+    }
+
     public function getTemplate(): string
     {
         return $this->template;

--- a/src/MediaProvider/ProviderInterface.php
+++ b/src/MediaProvider/ProviderInterface.php
@@ -16,6 +16,8 @@ use BitBag\SyliusCmsPlugin\Entity\MediaInterface;
 
 interface ProviderInterface
 {
+    public function setTemplate(string $string): ProviderInterface;
+
     public function getTemplate(): string;
 
     public function render(MediaInterface $media, array $options = []): string;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no 
| Related tickets | fixes #224 
| License         | MIT

I was looking at the documentation and noticed that the template option was missing.

The following change fixed it in my local installation