### PR TITLE
Render pages by section

### DIFF
--- a/src/Resources/config/services/twig.yml
+++ b/src/Resources/config/services/twig.yml
@@ -31,6 +31,17 @@ services:
         tags:
             - { name: twig.extension }
 
+    bitbag_sylius_cms_plugin.twig.extension.section_pages:
+        class: BitBag\SyliusCmsPlugin\Twig\Extension\RenderSectionPagesExtension
+        arguments:
+            - "@bitbag_sylius_cms_plugin.repository.page"
+            - "@bitbag_sylius_cms_plugin.repository.section"
+            - "@sylius.context.channel"
+            - "@sylius.context.locale"
+            - "@templating"
+        tags:
+            - { name: twig.extension }
+
     bitbag_sylius_cms_plugin.twig.extension.render_content:
         class: BitBag\SyliusCmsPlugin\Twig\Extension\RenderContentExtension
         arguments:

--- a/src/Resources/views/Shop/Section/_pagesBySection.html.twig
+++ b/src/Resources/views/Shop/Section/_pagesBySection.html.twig
@@ -1,0 +1,10 @@
+{% if pages is not empty %}
+    <div class="bitbag-page">
+        <h2>{{ section.name }}</h2>
+        <nav class="ui link list">
+            {% for page in pages %}
+                <a href="{{ path('bitbag_sylius_cms_plugin_shop_page_show', {'slug': page.slug}) }}" class="item">{{ page.name }}</a>
+            {% endfor %}
+        </nav>
+    </div>
+{% endif %}

--- a/src/Twig/Extension/RenderSectionPagesExtension.php
+++ b/src/Twig/Extension/RenderSectionPagesExtension.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusCmsPlugin\Twig\Extension;
+
+use BitBag\SyliusCmsPlugin\Repository\PageRepositoryInterface;
+use BitBag\SyliusCmsPlugin\Repository\SectionRepositoryInterface;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Twig\Extension\AbstractExtension;
+
+final class RenderSectionPagesExtension extends AbstractExtension
+{
+    /** @var PageRepositoryInterface */
+    private $pageRepository;
+
+    /** @var SectionRepositoryInterface */
+    private $sectionRepository;
+
+    /** @var ChannelContextInterface */
+    private $channelContext;
+
+    /** @var LocaleContextInterface */
+    private $localeContext;
+
+    /** @var EngineInterface */
+    private $templatingEngine;
+
+    public function __construct(
+        PageRepositoryInterface $pageRepository,
+        SectionRepositoryInterface $sectionRepository,
+        ChannelContextInterface $channelContext,
+        LocaleContextInterface $localeContext,
+        EngineInterface $templatingEngine
+    ) {
+        $this->pageRepository = $pageRepository;
+        $this->sectionRepository = $sectionRepository;
+        $this->channelContext = $channelContext;
+        $this->localeContext = $localeContext;
+        $this->templatingEngine = $templatingEngine;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new \Twig_Function('bitbag_cms_render_section_pages', [$this, 'renderSectionPages'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function renderSectionPages(string $sectionCode, ?string $template = null): string
+    {
+        $channelCode = $this->channelContext->getChannel()->getCode();
+        $section = $this->sectionRepository->findOneByCode($sectionCode, $this->localeContext->getLocaleCode());
+        $pages = $this->pageRepository->createShopListQueryBuilder($sectionCode, $channelCode)->getQuery()->getResult();
+
+        return $this->templatingEngine->render($template ?? '@BitBagSyliusCmsPlugin/Shop/Section/_pagesBySection.html.twig', [
+            'section' => $section,
+            'pages' => $pages,
+        ]);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

### Goal 
Render pages by section like "Your Store" in the footer:
![Screenshot from 2020-07-08 08-57-42](https://user-images.githubusercontent.com/2346295/86887738-51346780-c0f9-11ea-83bb-42312ff4e64e.png)

![Screenshot from 2020-07-08 09-37-14](https://user-images.githubusercontent.com/2346295/86891153-ab83f700-c0fe-11ea-863e-0b34eb7f4fd6.png)

ATM it's just a PR proposal. If you're ok with functionality, I'll add tests.