### PR TITLE
[Documentation] Removal of sitemap import in installation

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -54,16 +54,6 @@ bitbag_sylius_cms_plugin:
     resource: "@BitBagSyliusCmsPlugin/Resources/config/routing.yml"
 ```
 
-Import optional sitemap providers:
-```yaml
-# config/services.yaml
-...
-imports:
-...
-    - { resource: "@BitBagSyliusCmsPlugin/Resources/config/services/sitemap_provider.yml" }
-```
-
-
 Finish the installation by updating the database schema and installing assets:
 ```
 $ bin/console doctrine:migrations:diff


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I couldn't find `Resources/config/services/sitemap_provider.yml` in the master branch