### PR TITLE
Fix/code validation

### DIFF
--- a/src/Resources/config/validation/Block.yml
+++ b/src/Resources/config/validation/Block.yml
@@ -15,5 +15,9 @@ BitBag\SyliusCmsPlugin\Entity\Block:
                 minMessage: 'bitbag_sylius_cms_plugin.block.code.min_length'
                 maxMessage: 'bitbag_sylius_cms_plugin.block.code.max_length'
                 groups: ['bitbag']
+            - Regex:
+                  pattern: '/^[\w-]*$/'
+                  message: 'bitbag_sylius_cms_plugin.block.code.regex'
+                  groups: [ 'bitbag' ]
         translations:
             - Valid: ~

--- a/src/Resources/config/validation/FrequentlyAskedQuestion.yml
+++ b/src/Resources/config/validation/FrequentlyAskedQuestion.yml
@@ -17,6 +17,10 @@ BitBag\SyliusCmsPlugin\Entity\FrequentlyAskedQuestion:
                 min: 2
                 minMessage: 'bitbag_sylius_cms_plugin.frequently_asked_question.code.min_length'
                 groups: ['bitbag']
+            - Regex:
+                  pattern: '/^[\w-]*$/'
+                  message: 'bitbag_sylius_cms_plugin.frequently_asked_question.code.regex'
+                  groups: [ 'bitbag' ]
         position:
             - NotBlank:
                 message: 'bitbag_sylius_cms_plugin.frequently_asked_question.position.not_blank'

--- a/src/Resources/config/validation/Media.yml
+++ b/src/Resources/config/validation/Media.yml
@@ -15,6 +15,10 @@ BitBag\SyliusCmsPlugin\Entity\Media:
                 minMessage: 'bitbag_sylius_cms_plugin.media.code.min_length'
                 maxMessage: 'bitbag_sylius_cms_plugin.media.code.max_length'
                 groups: ['bitbag']
+            - Regex:
+                  pattern: '/^[\w-]*$/'
+                  message: 'bitbag_sylius_cms_plugin.media.code.regex'
+                  groups: [ 'bitbag' ]
         file:
             - Expression:
                 expression: '!(this.getPath() == null and this.getFile() == null)'

--- a/src/Resources/config/validation/Page.yml
+++ b/src/Resources/config/validation/Page.yml
@@ -15,5 +15,9 @@ BitBag\SyliusCmsPlugin\Entity\Page:
                 minMessage: 'bitbag_sylius_cms_plugin.page.code.min_length'
                 maxMessage: 'bitbag_sylius_cms_plugin.page.code.max_length'
                 groups: ['bitbag']
+            - Regex:
+                  pattern: '/^[\w-]*$/'
+                  message: 'bitbag_sylius_cms_plugin.page.code.regex'
+                  groups: [ 'bitbag' ]
         translations:
             - Valid: ~

--- a/src/Resources/config/validation/Section.yml
+++ b/src/Resources/config/validation/Section.yml
@@ -15,5 +15,9 @@ BitBag\SyliusCmsPlugin\Entity\Section:
                 minMessage: 'bitbag_sylius_cms_plugin.section.code.min_length'
                 maxMessage: 'bitbag_sylius_cms_plugin.section.code.max_length'
                 groups: ['bitbag']
+            - Regex:
+                  pattern: '/^[\w-]*$/'
+                  message: 'bitbag_sylius_cms_plugin.section.code.regex'
+                  groups: ['bitbag']
         translations:
             - Valid: ~

--- a/src/Resources/translations/validators.en.yml
+++ b/src/Resources/translations/validators.en.yml
@@ -8,6 +8,7 @@ bitbag_sylius_cms_plugin:
             not_blank: Code cannot be blank.
             min_length: Code must be at least {{ limit }} characters long.
             max_length: Code can not be longer than {{ limit }} characters.
+            regex: Block code can only be comprised of letters, numbers, dashes and underscores.
         name:
             min_length: Name must be at least {{ limit }} characters long.
             max_length: Name can not be longer than {{ limit }} characters.
@@ -23,6 +24,7 @@ bitbag_sylius_cms_plugin:
             not_blank: Code cannot be blank.
             min_length: Code must be at least {{ limit }} characters long.
             max_length: Code can not be longer than {{ limit }} characters.
+            regex: Page code can only be comprised of letters, numbers, dashes and underscores.
         name:
             not_blank: Name cannot be blank.
             min_length: Name must be at least {{ limit }} characters long.
@@ -47,6 +49,7 @@ bitbag_sylius_cms_plugin:
             not_blank: Code cannot be blank.
             min_length: Code must be at least {{ limit }} characters long.
             max_length: Code can not be longer than {{ limit }} characters.
+            regex: Code can only be comprised of letters, numbers, dashes and underscores.
         position:
             unique: There is an existing FAQ with this position.
             not_blank: Position cannot be blank.
@@ -62,6 +65,7 @@ bitbag_sylius_cms_plugin:
             not_blank: Code cannot be blank.
             min_length: Code must be at least {{ limit }} characters long.
             max_length: Code can not be longer than {{ limit }} characters.
+            regex: Section code can only be comprised of letters, numbers, dashes and underscores.
         name:
             not_blank: Name cannot be blank.
             min_length: Name must be at least {{ limit }} characters long.
@@ -72,6 +76,7 @@ bitbag_sylius_cms_plugin:
             not_blank: Code cannot be blank.
             min_length: Code must be at least {{ limit }} characters long.
             max_length: Code can not be longer than {{ limit }} characters.
+            regex: Media code can only be comprised of letters, numbers, dashes and underscores.
         file:
             not_blank: File cannot be blank.
         name:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | mentioned in https://github.com/BitBagCommerce/SyliusCmsPlugin/issues/289
| License         | MIT

Adds code validation with regex identical to sylius product. For existing resources with nonconformant codes this make cause BC break.
