### PR TITLE
Resource factory changed to TranslatableFactory

### DIFF
--- a/src/Resources/config/resources/block.yml
+++ b/src/Resources/config/resources/block.yml
@@ -8,6 +8,7 @@ sylius_resource:
                 form: BitBag\SyliusCmsPlugin\Form\Type\BlockType
                 repository: BitBag\SyliusCmsPlugin\Repository\BlockRepository
                 controller: BitBag\SyliusCmsPlugin\Controller\BlockController
+                factory: Sylius\Component\Resource\Factory\TranslatableFactory
             translation:
                 classes:
                     model: BitBag\SyliusCmsPlugin\Entity\BlockTranslation

--- a/src/Resources/config/resources/frequently_asked_question.yml
+++ b/src/Resources/config/resources/frequently_asked_question.yml
@@ -7,6 +7,7 @@ sylius_resource:
                 interface: BitBag\SyliusCmsPlugin\Entity\FrequentlyAskedQuestionInterface
                 form: BitBag\SyliusCmsPlugin\Form\Type\FrequentlyAskedQuestionType
                 repository: BitBag\SyliusCmsPlugin\Repository\FrequentlyAskedQuestionRepository
+                factory: Sylius\Component\Resource\Factory\TranslatableFactory
             translation:
                 classes:
                     model: BitBag\SyliusCmsPlugin\Entity\FrequentlyAskedQuestionTranslation

--- a/src/Resources/config/resources/media.yml
+++ b/src/Resources/config/resources/media.yml
@@ -8,6 +8,7 @@ sylius_resource:
                 form: BitBag\SyliusCmsPlugin\Form\Type\MediaType
                 repository: BitBag\SyliusCmsPlugin\Repository\MediaRepository
                 controller: BitBag\SyliusCmsPlugin\Controller\MediaController
+                factory: Sylius\Component\Resource\Factory\TranslatableFactory
             translation:
                 classes:
                     model: BitBag\SyliusCmsPlugin\Entity\MediaTranslation

--- a/src/Resources/config/resources/page.yml
+++ b/src/Resources/config/resources/page.yml
@@ -8,6 +8,7 @@ sylius_resource:
                 form: BitBag\SyliusCmsPlugin\Form\Type\PageType
                 repository: BitBag\SyliusCmsPlugin\Repository\PageRepository
                 controller: BitBag\SyliusCmsPlugin\Controller\PageController
+                factory: Sylius\Component\Resource\Factory\TranslatableFactory
             translation:
                 classes:
                     model: BitBag\SyliusCmsPlugin\Entity\PageTranslation

--- a/src/Resources/config/resources/section.yml
+++ b/src/Resources/config/resources/section.yml
@@ -7,6 +7,7 @@ sylius_resource:
                 interface: BitBag\SyliusCmsPlugin\Entity\SectionInterface
                 form: BitBag\SyliusCmsPlugin\Form\Type\SectionType
                 repository: BitBag\SyliusCmsPlugin\Repository\SectionRepository
+                factory: Sylius\Component\Resource\Factory\TranslatableFactory
             translation:
                 classes:
                     model: BitBag\SyliusCmsPlugin\Entity\SectionTranslation


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update UPGRADE-*.md file -->
| License         | MIT

Default resource factory for translatable entity should be TranslatableFactory.