### PR TITLE
Fix correct signature of implode

### DIFF
--- a/src/Controller/Helper/FormErrorsFlashHelper.php
+++ b/src/Controller/Helper/FormErrorsFlashHelper.php
@@ -42,7 +42,7 @@ final class FormErrorsFlashHelper implements FormErrorsFlashHelperInterface
             $errors[] = $error->getMessage();
         }
 
-        $message = $this->translator->trans('bitbag_sylius_cms_plugin.ui.form_was_submitted_with_errors') . ' ' . rtrim(implode($errors, ' '));
+        $message = $this->translator->trans('bitbag_sylius_cms_plugin.ui.form_was_submitted_with_errors') . ' ' . rtrim(implode(' ', $errors));
 
         $this->flashBag->set('error', $message);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update UPGRADE-*.md file -->
| Related tickets | N/A
| License         | MIT

Hello, 

The FormHerrorsFlashHelper use `implode` function with a deprecated signature, and this is not more available in PHP8. 

![image](https://user-images.githubusercontent.com/3168281/129006028-64646782-f887-4189-b00a-6de0fd68bf3f.png)

This PR fix the signature use :slightly_smiling_face: 