### PR TITLE
Fix wrong column name in join table

### DIFF
--- a/src/Resources/config/doctrine/Media.orm.yml
+++ b/src/Resources/config/doctrine/Media.orm.yml
@@ -69,7 +69,7 @@ BitBag\SyliusCmsPlugin\Entity\Media:
             joinTable:
                 name: bitbag_cms_media_channels
                 joinColumns:
-                    block_id:
+                    media_id:
                         referencedColumnName: id
                         onDelete: CASCADE
                 inverseJoinColumns:

--- a/src/Resources/config/doctrine/Page.orm.yml
+++ b/src/Resources/config/doctrine/Page.orm.yml
@@ -53,7 +53,7 @@ BitBag\SyliusCmsPlugin\Entity\Page:
             joinTable:
                 name: bitbag_cms_page_sections
                 joinColumns:
-                    block_id:
+                    page_id:
                         referencedColumnName: id
                         onDelete: CASCADE
                 inverseJoinColumns:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | kinda
| Deprecations?   | no
| Related tickets | None
| License         | MIT

Just changing columns names in join_table so that it make more sense :sweat_smile: 