### PR TITLE
Bug fix: Slug generation for values containing ampersand symbol

### DIFF
--- a/src/Resources/assets/admin/js/bitbag/bitbag-page-slug.js
+++ b/src/Resources/assets/admin/js/bitbag/bitbag-page-slug.js
@@ -79,7 +79,7 @@ export class HandleSlugUpdate {
 
     async _getValidSlug(url, value) {
         try {
-            const request = await fetch(`${url}?name=${value}`);
+            const request = await fetch(`${url}?name=${encodeURIComponent(value)}`);
             const response = await request.json();
             return response.slug;
         } catch (error) {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

### Expected result
While creating/editing a page name in admin panel (`/admin/pages`), if it contains ampersand symbol (`&`), the generated slug should contain all typed letters and remove only ampersand (or other symbols) from it.

Example:
![after](https://github.com/BitBagCommerce/SyliusCmsPlugin/assets/17049697/1095e31c-efe2-4755-b37a-11804aa5d802)

### Actual result
Whole part after ampersand is cut off from slug.

Example:
![before](https://github.com/BitBagCommerce/SyliusCmsPlugin/assets/17049697/0398273b-4c0a-43f1-9a59-a933de3a8179)

### Solution
As `&` is a special character in URLs, values containing it must be encoded while passing it as query parameter.
